### PR TITLE
Adds a nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,11 @@ aliases:
           - /^sync\/.*/
           - main
 
+parameters:
+  action:
+    type: string
+    default: ""
+
 commands:
   setup-git-credentials:
     steps:
@@ -127,13 +132,17 @@ jobs:
   check-links:
     docker:
       - image: cimg/ruby:3.1.2
+    parameters:
+      notify_slack:
+        type: boolean
+        default: false
     steps:
       - checkout
       - revenuecat/install-gem-unix-dependencies:
           cache-version: v1
       - run:
           name: Check links
-          command: bundle exec fastlane check_links
+          command: bundle exec fastlane check_links notify_slack:<< parameters.notify_slack >>
 
   check-categories:
     docker:
@@ -196,6 +205,10 @@ jobs:
     macos:
       xcode: 14.3.0
     shell: /bin/bash --login -o pipefail
+    parameters:
+      notify_slack:
+        type: boolean
+        default: false
     steps:
       - checkout
       - setup-git-credentials
@@ -203,24 +216,28 @@ jobs:
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - run:
-          name: Build Swift project
-          working_directory: projects/iOS/DocsTester
-          command: swift build
+          name: Build Android project
+          command: bundle exec fastlane build_ios notify_slack:<< parameters.notify_slack >>
 
   build-projects-android:
     executor:
       name: android/android-machine
       resource-class: medium
       tag: 2023.07.1
+    parameters:
+      notify_slack:
+        type: boolean
+        default: false
     steps:
       - checkout
+      - revenuecat/install-gem-unix-dependencies:
+          cache-version: v1
       - install-java
       - android/restore-gradle-cache:
           cache-prefix: v1
       - run:
           name: Build Android project
-          working_directory: projects/android
-          command: ./gradlew assembleDebug
+          command: bundle exec fastlane build_android notify_slack:<< parameters.notify_slack >>
       - android/save-gradle-cache:
           cache-prefix: v1
 
@@ -319,3 +336,14 @@ workflows:
     jobs:
       - lint-android-project: *non-syncing-branches
       - lint-ios-project: *non-syncing-branches
+
+  nightly-build:
+    when:
+      equal: [ build, << pipeline.parameters.action >> ]
+    jobs:
+      - build-projects-macos:
+          notify_slack: true
+      - build-projects-android:
+          notify_slack: true
+      - check-links:
+          notify_slack: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -208,7 +208,39 @@ end
 lane :check_links do |options|
     errors = check_links_in_folder(SOURCE_FOLDER)
     if errors.length > 0
+        if options[:notify_slack]
+            post_to_slack("Found #{errors.length} broken links:\n#{errors.join("\n")}")
+        end
         UI.user_error!("Found #{errors.length} broken links:\n#{errors.join("\n")}")
+    end
+end
+
+lane :build_android do |options|
+    begin
+        gradle(
+            task: "assembleDebug",
+            project_dir: "projects/android",
+            )
+    rescue => error
+        if options[:notify_slack]
+            post_to_slack("Android project build failed with error: #{error.message}")
+        end
+
+        raise error
+    end
+end
+
+lane :build_ios do |options|
+    Dir.chdir(root_dir) do
+        Dir.chdir("projects/iOS/DocsTester") do
+            sh("swift", "build", error_callback: ->(result) {
+                if options[:notify_slack]
+                    post_to_slack("iOS project build failed with error: #{result}")
+                end
+                UI.user_error!("iOS project build failed with error: #{result}")
+                raise error
+            })
+        end
     end
 end
 
@@ -380,4 +412,12 @@ def create_pr_to_main(title, body, repo_name, head_branch, github_pr_token, labe
         labels: labels,
         team_reviewers: ['support']
     )
+end
+
+def post_to_slack(message)
+    slack(
+        message: message,
+        slack_url: ENV["SLACK_WEBHOOK_URL"],
+        success: false,
+        )
 end


### PR DESCRIPTION
Adds a nightly build to check the Android and iOS projects are building. It also checks for broken links. If there's any failure, a slack message will be posted