### PR TITLE
`Observer mode`: add `usesStoreKit2IfAvailable` parameter

### DIFF
--- a/code_blocks/➡️ Migrating To RevenueCat/observer-mode_2.m
+++ b/code_blocks/➡️ Migrating To RevenueCat/observer-mode_2.m
@@ -2,4 +2,6 @@ RCPurchases.logLevel = RCLogLevelDebug;
 RCConfigurationBuilder *configuration = [RCConfiguration builderWithAPIKey:@<public_sdk_key>];
 configuration = [configuration withObserverMode:YES];
 configuration = [configuration withAppUserID:@<app_user_id>];
+// If your app uses StoreKit 2, you must enable it in the SDK
+configuration = [configuration withUsesStoreKit2IfAvailable:YES];
 [RCPurchases configureWithConfiguration:[configuration build]];

--- a/code_blocks/➡️ Migrating To RevenueCat/observer-mode_2.m
+++ b/code_blocks/➡️ Migrating To RevenueCat/observer-mode_2.m
@@ -1,7 +1,6 @@
 RCPurchases.logLevel = RCLogLevelDebug;
 RCConfigurationBuilder *configuration = [RCConfiguration builderWithAPIKey:@<public_sdk_key>];
-configuration = [configuration withObserverMode:YES];
-configuration = [configuration withAppUserID:@<app_user_id>];
 // If your app uses StoreKit 2, you must enable it in the SDK
-configuration = [configuration withUsesStoreKit2IfAvailable:YES];
+configuration = [configuration withObserverMode:YES, storeKit2:NO];
+configuration = [configuration withAppUserID:@<app_user_id>];
 [RCPurchases configureWithConfiguration:[configuration build]];

--- a/projects/iOS/DocsTester/Sources/DocsTester/DocsTester.swift
+++ b/projects/iOS/DocsTester/Sources/DocsTester/DocsTester.swift
@@ -10,6 +10,8 @@ final class Container {
                 .with(observerMode: true)
                 // Optionally set an app user ID for the user
                 .with(appUserID: UserManager.appUserID)
+                // If your app uses StoreKit 2, you must enable it in the SDK
+                .with(usesStoreKit2IfAvailable: true)
                 .build()
         )
         // END

--- a/projects/iOS/DocsTester/Sources/DocsTester/DocsTester.swift
+++ b/projects/iOS/DocsTester/Sources/DocsTester/DocsTester.swift
@@ -7,11 +7,10 @@ final class Container {
         Purchases.logLevel = .debug
         Purchases.configure(
             with: Configuration.Builder(withAPIKey: Constants.apiKey)
-                .with(observerMode: true)
+                // If your app uses StoreKit 2, you must enable it in the SDK
+                .with(observerMode: true, storeKit2: false)
                 // Optionally set an app user ID for the user
                 .with(appUserID: UserManager.appUserID)
-                // If your app uses StoreKit 2, you must enable it in the SDK
-                .with(usesStoreKit2IfAvailable: true)
                 .build()
         )
         // END


### PR DESCRIPTION
This is required since https://github.com/RevenueCat/purchases-ios/pull/3032.
