### PR TITLE
Allow trigger of open syncing pr through manual API call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,12 @@ workflows:
             branches:
               only: main
 
+  trigger-open-syncing-pr:
+    when:
+        equal: [ sync, << pipeline.parameters.action >> ]
+    jobs:
+      - open-syncing-pr:
+
   sync:
     jobs:
       - check-categories: *syncing-branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,7 @@ workflows:
 
   trigger-open-syncing-pr:
     when:
-        equal: [ sync, << pipeline.parameters.action >> ]
+      equal: [ sync, << pipeline.parameters.action >> ]
     jobs:
       - open-syncing-pr:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ workflows:
     when:
       equal: [ sync, << pipeline.parameters.action >> ]
     jobs:
-      - open-syncing-pr:
+      - open-syncing-pr
 
   sync:
     jobs:


### PR DESCRIPTION
## Motivation / Description

Sometimes CircleCI and webhooks from GitHub get broken. This will allow manually trigger an open syncing PR through CirclCI web UI.

## Changes introduced

Trigger `open-syncing-pr` when passing `action=sync` parameters when trigger workflow

## Jira ticket (if any)
## Additional comments
