### PR TITLE
[CI] Error when code block path doesn't exist

### DIFF
--- a/fastlane/code_blocks/code_blocks.rb
+++ b/fastlane/code_blocks/code_blocks.rb
@@ -234,7 +234,10 @@ def embed_code_from_files(code_blocks_group_with_tags)
         file_path = code_block_information['file']
         name = code_block_information['name']
         region = code_block_information['region']
-        next unless file_exists(file_path)
+        
+        unless file_exists(file_path)
+            Fastlane::UI.user_error!("Code block file doesn't exist: #{file_path}")
+        end
 
         file_content = extract_region_from_file(file_path, region, language)
         embedded_code_blocks_group.push "```#{language} #{name}\n#{file_content}\n```"


### PR DESCRIPTION
## Motivation / Description

Not erroring when a code block path caused a sync PR to be made that unintentially removed a bunch of code blocks

## Changes introduced

- Error when code block path doesn't exist

## Jira ticket (if any)
## Additional comments
