### PR TITLE
Rglanz/fix parent doc error

### DIFF
--- a/docs_source/🔑 Service Credentials/itunesconnect-app-specific-shared-secret/app-store-connect-api-key-configuration.md
+++ b/docs_source/🔑 Service Credentials/itunesconnect-app-specific-shared-secret/app-store-connect-api-key-configuration.md
@@ -2,7 +2,7 @@
 title: App Store Connect API Key Configuration
 slug: app-store-connect-api-key-configuration
 hidden: false
-parentDocSlug: itunesconnect-app-specific-shared-secret
+parentDoc: 649983b4c31b2e000a3c1859
 ---
 You may upload an App Store Connect API key for RevenueCat to import products and prices from App Store Connect. 
 

--- a/docs_source/🔑 Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
+++ b/docs_source/🔑 Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
@@ -3,7 +3,7 @@ title: In-App Purchase Key Configuration
 slug: in-app-purchase-key-configuration
 excerpt: Guide on how to set up iOS in-app purchase keys.
 hidden: false
-parentDocSlug: itunesconnect-app-specific-shared-secret
+parentDoc: 649983b4c31b2e000a3c1859
 ---
 For RevenueCat to securely authenticate and validate a [Subscription Offer](https://docs.revenuecat.com/docs/ios-subscription-offers) request with Apple, you'll need to upload an in-app purchase key. In order to enable [customer lookup](https://docs.revenuecat.com/docs/customer-lists#find-an-individual-customer) via Order ID for iOS apps, you'll also need to provide an Issuer ID.
 


### PR DESCRIPTION
## Motivation / Description
reverted `parentDocSlug` param to `parentDoc` in two docs

## Changes introduced

## Linear ticket (if any)

## Additional comments
