### PR TITLE
Add Capacitor SDK reference docs link

### DIFF
--- a/docs_source/📘 SDK Guides/reference.md
+++ b/docs_source/📘 SDK Guides/reference.md
@@ -14,4 +14,6 @@ The API reference documentation provides detailed information for each of the cl
 
 <a href="https://revenuecat.github.io/react-native-purchases-docs" target="_blank">React Native Reference :fa-arrow-right:</a>
 
+<a href="https://www.npmjs.com/package/@revenuecat/purchases-capacitor" target="_blank">Capacitor Reference :fa-arrow-right:</a>
+
 <a href="https://revenuecat.github.io/cordova-plugin-purchases-docs/" target="_blank">Cordova Reference :fa-arrow-right:</a>


### PR DESCRIPTION
## Motivation / Description
This adds a link to the Capacitor SDK reference docs which are currently visible in npm and the Github README to the docs