### PR TITLE
Remove message that says prepaid plan is not supported

### DIFF
--- a/docs_source/🚀 Getting Started/entitlements/android-products.md
+++ b/docs_source/🚀 Getting Started/entitlements/android-products.md
@@ -84,13 +84,6 @@ To mark a base plan as backwards compatible, click the overflow menu on the base
 
 ![](https://files.readme.io/0375be4-f309ab8-Screen_Shot_2022-07-07_at_2.12.18_PM.png "f309ab8-Screen_Shot_2022-07-07_at_2.12.18_PM.png")
 
-[block:callout]
-{
-  "type": "danger",
-  "title": "Prepaid base plans not yet supported",
-  "body": "RevenueCat does not yet support base plans with the renewal type \"Prepaid\"."
-}
-[/block]
 ## (Optional) Create an offer
 
 If you wish to create an offer for your base plan, you can do so from the subscription page by clicking "Add offer". Offers can be free trials, discounts, or simply special price setups that apply when a customer first purchases a subscription.


### PR DESCRIPTION
## Motivation / Description

Prepaid plans are supported. This message is outdated and confusing. 

In response to this community post: https://community.revenuecat.com/general-questions-7/docs-google-play-product-setup-prepaid-base-plans-not-yet-supported-but-they-work-3313?postid=10692#post10692

## Changes introduced

## Linear ticket (if any)

## Additional comments
