### PR TITLE
Add AdServices SDK version requirement

### DIFF
--- a/docs_source/🔌 Integrations & Events/attribution/apple-search-ads.md
+++ b/docs_source/🔌 Integrations & Events/attribution/apple-search-ads.md
@@ -6,7 +6,7 @@ hidden: false
 ---
 > 👍 
 > 
-> The Apple Search Ads (AdServices) integration is available on the [Pro](https://www.revenuecat.com/pricing) plan, Enterprise plan, and legacy Grow plan.
+> The Apple Search Ads (AdServices) integration is available on the [Pro](https://www.revenuecat.com/pricing) plan, Enterprise plan, and legacy Grow plan and is supported in iOS SDK version 4.10.0 and up
 
 With our Apple Search Ads integration you can:
 


### PR DESCRIPTION
## Motivation / Description

[DENG-526](https://linear.app/revenuecat/issue/DENG-526/apple-search-ads-missing-from-charts-no-attribution-for-subscribers-in)


## Changes introduced

Make it clear that AdServices requires SDK version 4.10.0 and up

## Linear ticket (if any)

## Additional comments
