### PR TITLE
Add Capacitor docs to getting started page

### DIFF
--- a/code_blocks/🚀 Getting Started/getting-started-capacitor-react-subcription-changes.ts
+++ b/code_blocks/🚀 Getting Started/getting-started-capacitor-react-subcription-changes.ts
@@ -1,0 +1,3 @@
+await Purchases.addCustomerInfoUpdateListener((customerInfo) => {
+  // handle any changes to customerInfo
+});

--- a/code_blocks/🚀 Getting Started/getting-started_capacitor-configure-sdk.ts
+++ b/code_blocks/🚀 Getting Started/getting-started_capacitor-configure-sdk.ts
@@ -1,0 +1,10 @@
+const onDeviceReady = async () => {
+  await Purchases.setLogLevel(LOG_LEVEL.DEBUG);
+  if (Capacitor.getPlatform() === 'ios') {
+    await Purchases.configure({ apiKey: <public_apple_api_key> });
+  } else if (Capacitor.getPlatform() === 'android') {
+    await Purchases.configure({ apiKey: <public_google_api_key> });
+  }
+  // OR: if building for Amazon, be sure to follow the installation instructions then:
+  await Purchases.configure({ apiKey: <public_amazon_api_key>, useAmazon: true });
+}

--- a/code_blocks/🚀 Getting Started/getting-started_capacitor-get-customer-info.ts
+++ b/code_blocks/🚀 Getting Started/getting-started_capacitor-get-customer-info.ts
@@ -1,0 +1,6 @@
+try {
+  const customerInfo = await Purchases.getCustomerInfo();
+  // access latest customerInfo
+} catch (error) {
+  // Error fetching customer info
+}

--- a/code_blocks/🚀 Getting Started/getting-started_capacitor-get-offerings.ts
+++ b/code_blocks/🚀 Getting Started/getting-started_capacitor-get-offerings.ts
@@ -1,0 +1,10 @@
+func displayUpsellScreen() {
+  try {
+    const offerings = await Purchases.getOfferings();
+    if (offerings.current !== null) {  
+      // Display current offering with offerings.current
+    }
+  } catch (error) {
+    // Handle error
+  }
+}

--- a/code_blocks/🚀 Getting Started/getting-started_capacitor-purchase.ts
+++ b/code_blocks/🚀 Getting Started/getting-started_capacitor-purchase.ts
@@ -1,0 +1,29 @@
+try {
+  const purchaseResult = await Purchases.purchasePackage({ aPackage: packageToBuy });
+  if (typeof purchaseResult.customerInfo.entitlements.active['my_entitlement_identifier'] !== "undefined") {
+    // Unlock that great "pro" content
+  }
+} catch (error: any) {
+  if (error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR) {
+    // Purchase cancelled
+  } else {
+    // Error making purchase
+  }
+}
+
+// Note: if you are not using offerings/packages to purchase In-app products, you can use purchaseStoreProduct and getProducts
+
+try {
+  const purchaseResult = await Purchases.purchaseStoreProduct({
+    product: productToBuy
+  });
+  if (typeof purchaseResult.customerInfo.entitlements.active['my_entitlement_identifier'] !== "undefined") {
+    // Unlock that great "pro" content
+  }
+} catch (error: any) {
+  if (error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR) {
+    // Purchase cancelled
+  } else {
+    // Error making purchase
+  }
+}

--- a/code_blocks/🚀 Getting Started/getting-started_capacitor-restore-purchases.ts
+++ b/code_blocks/🚀 Getting Started/getting-started_capacitor-restore-purchases.ts
@@ -1,0 +1,6 @@
+try {
+  const customerInfo = await Purchases.restorePurchases();
+  //... check customerInfo to see if entitlement is now active
+} catch (error) {
+  // Error restoring purchases
+}

--- a/docs_source/📙 Platform Resources/sample-apps.md
+++ b/docs_source/📙 Platform Resources/sample-apps.md
@@ -36,6 +36,10 @@ Sample apps are currently included in each SDK repository and demonstrate how to
   [Installation :fa-arrow-right:](doc:reactnative) | [Sample App :fa-arrow-right:](https://github.com/RevenueCat/react-native-purchases/tree/main/examples/MagicWeather)
   *Hybrid platform example. Hosted in our React Native SDK GitHub repository*
 
+## Capacitor/Ionic
+  [Installation :fa-arrow-right:](doc:ionic) | [Sample App :fa-arrow-right:](https://github.com/RevenueCat/purchases-capacitor/tree/main/example/purchase-tester)
+  *Hybrid platform example. Hosted in our Capacitor SDK GitHub repository*
+
 ## Cordova
   [Installation :fa-arrow-right:](doc:cordova) | [Sample App :fa-arrow-right:](https://github.com/RevenueCat/cordova-plugin-purchases/tree/main/examples/cordova-sample/MyApp)
   *Hybrid platform example. Hosted in our Cordova SDK GitHub repository*

--- a/docs_source/🚀 Getting Started/getting-started.md
+++ b/docs_source/🚀 Getting Started/getting-started.md
@@ -158,7 +158,7 @@ Install the SDK on your preferred platform with our installation guides below.
 - [Android Installation ](doc:android)
 - [React Native Installation ](doc:reactnative) 
 - [Flutter Installation ](doc:flutter)
-- [Ionic Installation ](doc:ionic)
+- [Capacitor / Ionic Installation ](doc:ionic)
 - [Cordova Installation ](doc:cordova) 
 - [Unity Installation ](doc:unity) 
 - [macOS / Catalyst Installation ](doc:macos)

--- a/docs_source/🚀 Getting Started/getting-started.md
+++ b/docs_source/🚀 Getting Started/getting-started.md
@@ -158,8 +158,8 @@ Install the SDK on your preferred platform with our installation guides below.
 - [Android Installation ](doc:android)
 - [React Native Installation ](doc:reactnative) 
 - [Flutter Installation ](doc:flutter)
-- [Cordova Installation ](doc:cordova) 
 - [Ionic Installation ](doc:ionic)
+- [Cordova Installation ](doc:cordova) 
 - [Unity Installation ](doc:unity) 
 - [macOS / Catalyst Installation ](doc:macos)
 
@@ -208,6 +208,11 @@ Make sure you configure _Purchases_ with your public SDK key only. You can read 
     "language": "typescript",
     "name": "React Native",
     "file": "code_blocks/🚀 Getting Started/getting-started_6.ts"
+  },
+  {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/🚀 Getting Started/getting-started_capacitor-configure-sdk.ts"
   },
   {
     "language": "javascript",
@@ -269,6 +274,11 @@ Below is an example of fetching Offerings. You can utilize Offerings to organize
     "language": "javascript",
     "name": "React Native",
     "file": "code_blocks/🚀 Getting Started/getting-started_14.js"
+  },
+  {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/🚀 Getting Started/getting-started_capacitor-get-offerings.ts"
   },
   {
     "language": "javascript",
@@ -341,6 +351,11 @@ The code sample below shows the process of purchasing a package and confirming i
     "file": "code_blocks/🚀 Getting Started/getting-started_23.js"
   },
   {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/🚀 Getting Started/getting-started_capacitor-purchase.ts"
+  },
+  {
     "language": "javascript",
     "name": "Cordova",
     "file": "code_blocks/🚀 Getting Started/getting-started_24.js"
@@ -407,6 +422,11 @@ If you're not using Entitlements (you probably should be!) you can check the arr
     "language": "javascript",
     "name": "React Native",
     "file": "code_blocks/🚀 Getting Started/getting-started_32.js"
+  },
+  {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/🚀 Getting Started/getting-started_capacitor-get-customer-info.ts"
   },
   {
     "language": "javascript",
@@ -479,6 +499,11 @@ RevenueCat enables your users to restore their in-app purchases, reactivating an
     "file": "code_blocks/🚀 Getting Started/getting-started_41.js"
   },
   {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/🚀 Getting Started/getting-started_capacitor-restore-purchases.ts"
+  },
+  {
     "language": "javascript",
     "name": "Cordova",
     "file": "code_blocks/🚀 Getting Started/getting-started_42.js"
@@ -542,6 +567,11 @@ Depending on your app, it may be sufficient to ignore the delegate and simply ha
     "language": "javascript",
     "name": "React Native",
     "file": "code_blocks/🚀 Getting Started/getting-started_49.js"
+  },
+  {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/🚀 Getting Started/getting-started-capacitor-react-subcription-changes.ts"
   },
   {
     "language": "javascript",


### PR DESCRIPTION
## Motivation / Description
We added Capacitor docs in #333 but those were incomplete since we only added them to each individual page but not the `Getting started` page. This brings the Capacitor plugin docs to the getting started page and the sample apps page.

