### PR TITLE
Make a note that Sandbox is sloooooowwwwww

### DIFF
--- a/docs_source/🧰 Test - Launch/sandbox/apple-app-store.md
+++ b/docs_source/🧰 Test - Launch/sandbox/apple-app-store.md
@@ -209,6 +209,10 @@ Build and run your app on your device. When you attempt to make a purchase, you 
 > 
 > Apple may prompt you to sign in with an Apple ID whenever you make or restore a purchase. When using the SDK, this could only happen when you call `.purchase(package:)` or `.restorePurchases`. Developers don't have control over the type of prompt that is shown (Face ID, Touch ID, password, etc.)
 
+> ❗️ Sandbox May Be Slow
+> 
+> Apple's App Store Sandbox is notoriously unperformant. A sandbox purchase experience may take upwards of 15s to fully complete. This is normal. In production, total purchase times are usually in the low seconds.
+
 # Verify the Transaction Appears in the Dashboard
 
 After a purchase is successful, you should be able to view the transaction immediately in the RevenueCat dashboard. If the purchase does not appear in the dashboard, it's **not** being tracked by RevenueCat.


### PR DESCRIPTION
Based on customer feedback

> Test purchases are slow (like 8 seconds per step) on the testing devices. This has been discussed in public forums as being Apple's fault and only happening in development mode and not in production, but there are confusing comments sometimes and I'm concerned the issue will persist. It'd be nice to have this behavior documented somewhere if it isn't.

## Motivation / Description

## Changes introduced

## Linear ticket (if any)

## Additional comments
