### PR TITLE
Update event-types-and-fields.md

### DIFF
--- a/docs_source/🔌 Integrations & Events/webhooks/event-types-and-fields.md
+++ b/docs_source/🔌 Integrations & Events/webhooks/event-types-and-fields.md
@@ -89,7 +89,7 @@ RevenueCat sends webhooks in response to events that occur in your app. Here the
     "9-5": "✅",
     "9-6": "❌",
     "10-0": "`TRANSFER`",
-    "10-1": "A transfer of transactions and entitlements was initiated between one App User ID(s) to another.",
+    "10-1": "A transfer of transactions and entitlements was initiated between one App User ID(s) to another.  \n  \nPlease note: The webhook will only be sent for the destination user despite us displaying this event in both customer histories because the event body is exactly the same for both users.",
     "10-2": "✅",
     "10-3": "✅",
     "10-4": "✅",


### PR DESCRIPTION
## Motivation / Description
Updating description according to DENG-551

## Changes introduced
On webhook events and types, changed transfer event definition as follows: "A transfer of transactions and entitlements was initiated between one App User ID(s) to another. \n \nPlease note: The webhook will only be sent for the destination user despite us displaying this event in both customer histories because the event body is exactly the same for both users."

## Linear ticket (if any)
https://linear.app/revenuecat/issue/DENG-551/not-generating-webhooks-for-some-transfer-events
