### PR TITLE
Fix iOS lint

### DIFF
--- a/code_blocks/🛠 Tools/paywalls/paywalls_4.swift
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_4.swift
@@ -5,16 +5,13 @@ import RevenueCatUI
 
 class ViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-
     @IBAction func presentPaywall() {
         let controller = PaywallViewController()
         controller.delegate = self
 
         present(controller, animated: true, completion: nil)
     }
+
 }
 
 extension ViewController: PaywallViewControllerDelegate {


### PR DESCRIPTION
This broke when SwiftLint 0.53.0 came out with a new "Unneeded Overridden Functions" rule.
