### PR TITLE
Add Capacitor Vue.js initialization docs with note about reactivity usages

### DIFF
--- a/code_blocks/🚀 Getting Started/installation/ionic_vuejs_capacitor.ts
+++ b/code_blocks/🚀 Getting Started/installation/ionic_vuejs_capacitor.ts
@@ -1,0 +1,18 @@
+import {LOG_LEVEL, Purchases} from "@revenuecat/purchases-capacitor";
+
+const app = createApp(App)
+  .use(IonicVue)
+  .use(router);
+
+const configure = async () => {
+  await Purchases.setLogLevel({ level: LOG_LEVEL.DEBUG }); // Enable to get debug logs
+  await Purchases.configure({
+    apiKey: "my_api_key",
+    appUserID: "my_app_user_id" // Optional
+  });
+};
+
+router.isReady().then(() => {
+  app.mount('#app');
+  configure().then(() => { "RevenueCat SDK configured!" });
+});

--- a/docs_source/🚀 Getting Started/installation/ionic.md
+++ b/docs_source/🚀 Getting Started/installation/ionic.md
@@ -78,3 +78,21 @@ Import the plugin object then use its static methods:
   }
 ]
 [/block]
+
+## Vue.js
+
+> 🚧 Important note if using Vue.js reactivity wrappers
+> 
+> If using Vue.js and its reactivity wrappers like [reactive](https://vuejs.org/api/reactivity-core.html#reactive) or [readonly](https://vuejs.org/api/reactivity-core.html#readonly), make sure you pass the raw objects to the capacitor plugin methods. You can use the [toRaw](https://vuejs.org/api/reactivity-advanced.html#toraw) method for that.
+
+Import the plugin object then use its static methods:
+
+[block:file]
+[
+  {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/🚀 Getting Started/installation/ionic_vuejs_capacitor.ts"
+  }
+]
+[/block]

--- a/docs_source/🚀 Getting Started/installation/ionic.md
+++ b/docs_source/🚀 Getting Started/installation/ionic.md
@@ -83,7 +83,7 @@ Import the plugin object then use its static methods:
 
 > 🚧 Important note if using Vue.js reactivity wrappers
 > 
-> If using Vue.js and its reactivity wrappers like [reactive](https://vuejs.org/api/reactivity-core.html#reactive) or [readonly](https://vuejs.org/api/reactivity-core.html#readonly), make sure you pass the raw objects to the capacitor plugin methods. You can use the [toRaw](https://vuejs.org/api/reactivity-advanced.html#toraw) method for that.
+> If using Vue.js and its Reactivity API wrappers like [reactive](https://vuejs.org/api/reactivity-core.html#reactive) or [readonly](https://vuejs.org/api/reactivity-core.html#readonly), make sure you pass the raw objects (rather than `Proxy` objects) to the Capacitor plugin methods. You can use the [toRaw](https://vuejs.org/api/reactivity-advanced.html#toraw) method to convert to the raw object.
 
 Import the plugin object then use its static methods:
 


### PR DESCRIPTION
## Motivation / Description
We've had several problems in our Capacitor plugin with people using Vue.js and reactivity, since they may be happening proxy objects to our plugin methods which is not supported. This adds a small sample for initializing the SDK in a Vue.js project and adds a note for devs to make sure they use `toRaw` when using these proxy objects
