### PR TITLE
Add Capacitor migration guide link

### DIFF
--- a/docs_source/📘 SDK Guides/migration-guides.md
+++ b/docs_source/📘 SDK Guides/migration-guides.md
@@ -12,3 +12,4 @@ As RevenueCat's SDK evolves over time and continues to simplify purchasing logic
 - [Android Native - 4.x to 5.x Migration ](doc:android-native-4x-to-5x-migration)
 - [Android Native - 5.x to 6.x Migration](https://github.com/RevenueCat/purchases-android/blob/main/migrations/v6-MIGRATION.md)
 - [Android Native - 6.x to 7.x Migration](https://github.com/RevenueCat/purchases-android/blob/main/migrations/v7-MIGRATION.md)
+- [Capacitor - 5.x to 6.x Migration](https://github.com/RevenueCat/purchases-capacitor/blob/main/migrations/v6-MIGRATION.md)


### PR DESCRIPTION
## Motivation / Description
This adds a link to the Capacitor plugin migration guide after RevenueCat took over maintenance 
