### PR TITLE
Update App Store Connect API access level suggestion

### DIFF
--- a/docs_source/🔑 Service Credentials/itunesconnect-app-specific-shared-secret/app-store-connect-api-key-configuration.md
+++ b/docs_source/🔑 Service Credentials/itunesconnect-app-specific-shared-secret/app-store-connect-api-key-configuration.md
@@ -14,9 +14,9 @@ On App Store Connect, [create a new App Store Connect API key](https://developer
 
 
 
-The newly created key needs to have at least the access level **Developer**:
+The newly created key needs to have at least the access level **App Manager**:
 
-![](https://files.readme.io/0f8e598-Screenshot_2023-01-03_at_22.00.26.png "Screenshot 2023-01-03 at 22.00.26.png")
+![](https://files.readme.io/2153907-generate_api_key.png "Screenshot 2023-01-03 at 22.00.26.png")
 
 
 


### PR DESCRIPTION
## Motivation / Description

We actually require App Manager level access to obtain pricing information for Apple subscription offers. Updating our docs so that users will begin uploading keys that have sufficient permission. 

## Changes introduced

I didn't know how to update the screenshot in the docs directly from Github, so I ended up updating the screenshot directly in readme.io first and use the url there to replace this in the docs. It should work. Hope that's okay.

## Linear ticket (if any)

## Additional comments
