### PR TITLE
`Debugging`: debug overlay supports `macOS` and `visionOS`

### DIFF
--- a/docs_source/🧰 Test - Launch/debugging.md
+++ b/docs_source/🧰 Test - Launch/debugging.md
@@ -65,7 +65,7 @@ RevenueCat's SDK will log important information and errors to help you understan
 
 RevenueCat's iOS 4.22.0+ and Android 6.9.2+ SDKs provide an overlay for your app that displays relevant details of the SDK configuration. The debug overlay includes each of your configured Offerings, with the option to purchase any of the products and validate access to entitlements.
 
-## iOS
+## iOS / macOS / visionOS
 
 [block:image]
 {


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-ios/pull/2648#issuecomment-1751725764
