### PR TITLE
Add docs for using custom fonts with Android paywalls

### DIFF
--- a/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_google_font.kt
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_google_font.kt
@@ -1,0 +1,24 @@
+class MyActivity : ComponentActivity(), PaywallResultHandler {
+    private lateinit var paywallActivityLauncher: PaywallActivityLauncher
+    private val googleFontProvider = GoogleFontProvider(R.array.com_google_android_gms_fonts_certs)
+    private val fontFamily = PaywallFontFamily(
+        fonts = listOf(
+            PaywallFont.GoogleFont("GOOGLE_FONT_NAME", googleFontProvider)
+        )
+    )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        paywallActivityLauncher = PaywallActivityLauncher(this, this)
+        ...
+    }
+
+    ...
+
+    fun launchPaywall(offering: Offering? = null) {
+        paywallActivityLauncher.launch(
+            offering,
+            CustomParcelizableFontProvider(fontFamily)
+        )
+    }
+}

--- a/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_google_font.kt
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_google_font.kt
@@ -10,10 +10,7 @@ class MyActivity : ComponentActivity(), PaywallResultHandler {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         paywallActivityLauncher = PaywallActivityLauncher(this, this)
-        ...
     }
-
-    ...
 
     fun launchPaywall(offering: Offering? = null) {
         paywallActivityLauncher.launch(

--- a/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_resource_font.kt
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_resource_font.kt
@@ -9,10 +9,7 @@ class MyActivity : ComponentActivity(), PaywallResultHandler {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         paywallActivityLauncher = PaywallActivityLauncher(this, this)
-        ...
     }
-
-    ...
 
     fun launchPaywall(offering: Offering? = null) {
         paywallActivityLauncher.launch(

--- a/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_resource_font.kt
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_activity_single_resource_font.kt
@@ -1,0 +1,23 @@
+class MyActivity : ComponentActivity(), PaywallResultHandler {
+    private lateinit var paywallActivityLauncher: PaywallActivityLauncher
+    private val fontFamily = PaywallFontFamily(
+        fonts = listOf(
+            PaywallFont.ResourceFont(R.font.my_font)
+        )
+    )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        paywallActivityLauncher = PaywallActivityLauncher(this, this)
+        ...
+    }
+
+    ...
+
+    fun launchPaywall(offering: Offering? = null) {
+        paywallActivityLauncher.launch(
+            offering, 
+            CustomParcelizableFontProvider(fontFamily)
+        )
+    }
+}

--- a/code_blocks/🛠 Tools/paywalls/paywalls_compose_font_per_style.kt
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_compose_font_per_style.kt
@@ -1,0 +1,16 @@
+@Composable
+fun MyComposable() {
+    PaywallDialog(
+        PaywallDialogOptions.Builder { /* on dismiss */ }
+            .setFontProvider(object : FontProvider {
+                override fun getFont(type: TypographyType): FontFamily? {
+                    return when (type) {
+                        TypographyType.HEADLINE_LARGE -> headlineFontFamily
+                        TypographyType.BODY_LARGE -> bodyFontFamily
+                        else -> null // Will use default font
+                    }
+                }
+            })
+            .build()
+    )
+}

--- a/code_blocks/🛠 Tools/paywalls/paywalls_compose_single_font.kt
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_compose_single_font.kt
@@ -1,0 +1,8 @@
+@Composable
+fun MyComposable() {
+    PaywallDialog(
+        PaywallDialogOptions.Builder { /* on dismiss */ }
+            .setFontProvider(CustomFontProvider(myFontFamily))
+            .build()
+    )
+}

--- a/docs_source/🛠 Tools/paywalls/displaying-paywalls.md
+++ b/docs_source/🛠 Tools/paywalls/displaying-paywalls.md
@@ -189,7 +189,7 @@ If you need more control over your font preferences, you can create your own `Fo
     "language": "kotlin",
     "name": "Activity single Google font",
     "file": "code_blocks/🛠 Tools/paywalls/paywalls_activity_single_google_font.kt"
-  },
+  }
 ]
 [/block]
 

--- a/docs_source/🛠 Tools/paywalls/displaying-paywalls.md
+++ b/docs_source/🛠 Tools/paywalls/displaying-paywalls.md
@@ -104,7 +104,7 @@ RevenueCat Paywalls will, by default, show paywalls fullscreen and there are mul
 
 - Depending on an entitlement with `PaywallDialog`
 - Custom logic with `PaywallDialog`
-- Manually with `PaywallView`, `PaywallDialog`, or `PaywallActivityLauncher`
+- Manually with `Paywall`, `PaywallDialog`, or `PaywallActivityLauncher`
 
 [block:file]
 [
@@ -155,6 +155,41 @@ This is all remotely configured and RevenueCatUI handles all the intro offer eli
     "name": "Specific Offering",
     "file": "code_blocks/🛠 Tools/paywalls/paywalls_6.kt"
   }
+]
+[/block]
+
+### How to use custom fonts
+
+Paywalls can be configured to use the same font as your app using a `FontProvider` when using Compose or `ParcelizableFontProvider` when using `PaywallActivityLauncher`. These can be passed to the `PaywallOptions` or `PaywallDialogOptions` builders or directly to the `launch` method in `PaywallActivityLauncher` into all methods for displaying the paywall.
+
+By default, a paywall will not use a font provider. This uses the current Material3 theme's Typography by default.
+
+We offer a `CustomFontProvider` and `CustomParcelizableFontProvider` which receives a single font family to use by all text styles in the paywall, if you don't need extra granularity control.
+
+If you need more control over your font preferences, you can create your own `FontProvider`. See the following examples for some common use cases:
+
+[block:file]
+[
+  {
+    "language": "kotlin",
+    "name": "Compose single font",
+    "file": "code_blocks/🛠 Tools/paywalls/paywalls_compose_single_font.kt"
+  },
+  {
+    "language": "kotlin",
+    "name": "Compose font per style",
+    "file": "code_blocks/🛠 Tools/paywalls/paywalls_compose_font_per_style.kt"
+  },
+  {
+    "language": "kotlin",
+    "name": "Activity single resource font",
+    "file": "code_blocks/🛠 Tools/paywalls/paywalls_activity_single_resource_font.kt"
+  },
+  {
+    "language": "kotlin",
+    "name": "Activity single Google font",
+    "file": "code_blocks/🛠 Tools/paywalls/paywalls_activity_single_google_font.kt"
+  },
 ]
 [/block]
 


### PR DESCRIPTION
## Motivation / Description
This adds some extra documentation to the paywalls section explaining how to use custom fonts. 

We should hold this until a new release has been published with these new APIs
