### PR TITLE
Paywalls: Add limitations when using developer determined offers

### DIFF
--- a/docs_source/🛠 Tools/paywalls.md
+++ b/docs_source/🛠 Tools/paywalls.md
@@ -103,6 +103,9 @@ Therefore, you can create a unique Paywall for each of your Offerings, and can c
 * ❌ macOS
 * ❌ tvOS
 
+## Android's Google Play developer determined offers
+Paywalls in Android will use the default subscription option which, in case you use [developer determined offers](doc:google-play-offers#eligibility-criteria), will always be available, providing these types of offers always to your users. If you want to avoid this behavior when using paywalls, add the `rc-ignore-offer` tag to the developer determined offer from your product.
+
 # Next Steps
 
 * Now that you know how our paywalls work, read about [creating paywalls](doc:creating-paywalls)


### PR DESCRIPTION
## Motivation / Description
Currently, developer determined offers don't work great with paywalls since developers can't choose the subscripiton option they want to apply. So if a developer uses these offers, the developer determined offer will always be available, so end users could always have access to them. This adds a section to the docs mentioning this limitation and suggesting using the `rc-ignore-offer` for now to be able to avoid using those offers in paywalls.