### PR TITLE
Fix angular enable debug logs docs

### DIFF
--- a/code_blocks/🚀 Getting Started/installation/ionic_angular_capacitor.ts
+++ b/code_blocks/🚀 Getting Started/installation/ionic_angular_capacitor.ts
@@ -4,7 +4,7 @@ import { Purchases, LOG_LEVEL } from '@revenuecat/purchases-capacitor';
 
 constructor(platform: Platform) {
     platform.ready().then(async () => {
-        await Purchases.setLogLevel(LOG_LEVEL.DEBUG); // Enable to get debug logs
+        await Purchases.setLogLevel({ level: LOG_LEVEL.DEBUG }); // Enable to get debug logs
         await Purchases.configure({
             apiKey: "my_api_key",
             appUserID: "my_app_user_id" // Optional


### PR DESCRIPTION
## Motivation / Description
We were using the wrong syntax in the angular.js example of how to enable debug logs in capacitor. This fixes that with the proper syntax
