### PR TITLE
Adds allowlist to link checks

### DIFF
--- a/fastlane/checks.rb
+++ b/fastlane/checks.rb
@@ -5,11 +5,15 @@ def check_links_in_folder(folder)
     markdown_files(folder).each do |markdown_file|
         errors = check_links_in_file(markdown_file)
         errors.each do |error|
-            all_errors << error unless all_errors.include?(error)  # Add error if not already present
+            all_errors << error unless all_errors.include?(error) # Add error if not already present
         end
     end
     return all_errors
 end
+
+ALLOWLISTED_URLS = [
+    "https://www.amazon.com/gp/mas/get/amazonapp",
+]
 
 def check_links_in_file(markdown_file)
     markdown_content = get_file_contents(markdown_file)
@@ -26,6 +30,11 @@ def check_links_in_file(markdown_file)
     errors = []
     links.each do |url|
         next unless url.start_with?('http')
+
+        if ALLOWLISTED_URLS.include?(url)
+            Fastlane::UI.message("Skipping allowlisted URL: #{url}")
+            next
+        end
 
         begin
             response = URI.open(url)


### PR DESCRIPTION
"https://www.amazon.com/gp/mas/get/amazonapp" is giving a 404, but it's a link that's actually working. If you open it from your browser it works.

See a failing job https://app.circleci.com/pipelines/github/RevenueCat/revenuecat-docs/1677/workflows/08ad2498-9634-4807-9701-1e4a272e8f4a/jobs/9428

I added an allow list so these type of errors don't make the job fail