### PR TITLE
Disclaimer on Sub Status only being provided since Nov 2023

### DIFF
--- a/docs_source/🔌 Integrations & Events/third-party-integrations/amplitude.md
+++ b/docs_source/🔌 Integrations & Events/third-party-integrations/amplitude.md
@@ -320,3 +320,5 @@ Whenever RevenueCat sends an event to Amplitude, we'll update the `rc_subscripti
 | paused              | The customer has a paid subscription which has been paused and is set to resume at some future date.       
 
 For customers with multiple active subscriptions, this attribute will represent the status of only the subscription for which the most recent event occurred. Therefore, we recommend using `rc_active_entitlements` to understand whether your customers have multiple active subscriptions to be accounted for.
+
+Please note that since this attribute is set and updated when events are delivered, subscribers with events prior to our release of this attribute (during November 2023) will not have this attribute set until/unless a future event (renewal, cancellation, etc) occurs.

--- a/docs_source/🔌 Integrations & Events/third-party-integrations/braze.md
+++ b/docs_source/🔌 Integrations & Events/third-party-integrations/braze.md
@@ -320,3 +320,5 @@ Whenever RevenueCat sends an event to Braze, we'll update the `rc_subscription_s
 | paused              | The customer has a paid subscription which has been paused and is set to resume at some future date.       
 
 For customers with multiple active subscriptions, this attribute will represent the status of only the subscription for which the most recent event occurred. Therefore, we recommend using `rc_active_entitlements` to understand whether your customers have multiple active subscriptions to be accounted for.
+
+Please note that since this attribute is set and updated when events are delivered, subscribers with events prior to our release of this attribute (during November 2023) will not have this attribute set until/unless a future event (renewal, cancellation, etc) occurs.

--- a/docs_source/🔌 Integrations & Events/third-party-integrations/mixpanel.md
+++ b/docs_source/🔌 Integrations & Events/third-party-integrations/mixpanel.md
@@ -277,3 +277,7 @@ Whenever RevenueCat sends an event to Mixpanel, we'll update the `rc_subscriptio
 | promotional         | The customer has access to an entitlement through a granted RevenueCat promotional subscription.                                   |
 | expired_promotional | The customer previously had access to an entitlement through a granted RevenueCat promotional subscription that has since expired. |
 | paused              | The customer has a paid subscription which has been paused and is set to resume at some future date.
+
+For customers with multiple active subscriptions, this attribute will represent the status of only the subscription for which the most recent event occurred.
+
+Please note that since this attribute is set and updated when events are delivered, subscribers with events prior to our release of this attribute (during November 2023) will not have this attribute set until/unless a future event (renewal, cancellation, etc) occurs.

--- a/docs_source/🔌 Integrations & Events/third-party-integrations/onesignal.md
+++ b/docs_source/🔌 Integrations & Events/third-party-integrations/onesignal.md
@@ -358,3 +358,7 @@ Whenever RevenueCat sends an event to OneSignal, we'll send a `subscription_stat
 | promotional         | The customer has access to an entitlement through a granted RevenueCat promotional subscription.                                   |
 | expired_promotional | The customer previously had access to an entitlement through a granted RevenueCat promotional subscription that has since expired. |
 | paused              | The customer has a paid subscription which has been paused and is set to resume at some future date.       
+
+For customers with multiple active subscriptions, this attribute will represent the status of only the subscription for which the most recent event occurred.
+
+Please note that since this attribute is set and updated when events are delivered, subscribers with events prior to our release of this attribute (during November 2023) will not have this attribute set until/unless a future event (renewal, cancellation, etc) occurs.

--- a/docs_source/🔌 Integrations & Events/third-party-integrations/segment.md
+++ b/docs_source/🔌 Integrations & Events/third-party-integrations/segment.md
@@ -311,3 +311,7 @@ Whenever RevenueCat sends an event to Segment, we'll update the `rc_subscription
 | promotional         | The customer has access to an entitlement through a granted RevenueCat promotional subscription.                                   |
 | expired_promotional | The customer previously had access to an entitlement through a granted RevenueCat promotional subscription that has since expired. |
 | paused              | The customer has a paid subscription which has been paused and is set to resume at some future date.       
+
+For customers with multiple active subscriptions, this attribute will represent the status of only the subscription for which the most recent event occurred.
+
+Please note that since this attribute is set and updated when events are delivered, subscribers with events prior to our release of this attribute (during November 2023) will not have this attribute set until/unless a future event (renewal, cancellation, etc) occurs.


### PR DESCRIPTION
## Motivation / Description

Adding a disclaimer to the Subscription Status attribute so that customers understand it will only be set for users with events from Nov 23 forward.

## Changes introduced

## Linear ticket (if any)

## Additional comments
