### PR TITLE
Adds offer code pricing instructions

### DIFF
--- a/docs_source/💰 Subscription Guidance/subscription-offers.md
+++ b/docs_source/💰 Subscription Guidance/subscription-offers.md
@@ -92,10 +92,6 @@ The `subscriptionOptions` property also has a number of convenience properties t
 
 Apple supports several types of subscription offers which we detail in our [Apple Subscription Offers](doc:ios-subscription-offers) guide.
 
-> 🚧 Accurate revenue tracking not supported for offer codes
-> 
-> Due to limitations of available information on App Store Offer Codes, accurate revenue tracking is not yet supported in the RevenueCat dashboard. All initial purchases made with Offer Codes are assumed to be $0 transactions. Revenue from subsequent renewal transactions will be tracked normally.
-
 ## Google Play
 
 Google has several types of subscription offers, as well as Promo Codes to offer to customers.

--- a/docs_source/💰 Subscription Guidance/subscription-offers/ios-subscription-offers.md
+++ b/docs_source/💰 Subscription Guidance/subscription-offers/ios-subscription-offers.md
@@ -206,7 +206,7 @@ When users click your link within your app to redeem the offer code, it will tak
 
 ## Considerations
 
-- Due to limitations of available information on Offer Codes, accurate revenue tracking is not yet supported in the RevenueCat dashboard. All initial purchases made with Offer Codes are assumed to be $0 transactions. Revenue from subsequent renewal transactions will be tracked normally. 
+- In order for RevenueCat to accurately track revenue for offer codes, you will need to upload an in-app purchase key. See our guide on [In-App Purchase Key Configuration](doc:in-app-purchase-key-configuration) for step-by-step instructions.
 
 # Next Steps
 


### PR DESCRIPTION
## Motivation / Description
Slack: https://revenuecat.slack.com/archives/C0249RT3RMZ/p1700148440374239 

## Changes introduced
- Removes messaging that revenue from Apple offer code cannot be tracked 

## Linear ticket (if any)

## Additional comments
