### PR TITLE
Add trusted entitlement hybrids documentation

### DIFF
--- a/code_blocks/👥 Customers/trusted-entitlements-capacitor.ts
+++ b/code_blocks/👥 Customers/trusted-entitlements-capacitor.ts
@@ -1,0 +1,4 @@
+await Purchases.configure({ 
+    apiKey: <public_api_key>, 
+    entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL
+});

--- a/code_blocks/👥 Customers/trusted-entitlements-rn.ts
+++ b/code_blocks/👥 Customers/trusted-entitlements-rn.ts
@@ -1,0 +1,4 @@
+await Purchases.configure({ 
+    apiKey: <public_api_key>, 
+    entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL
+});

--- a/code_blocks/👥 Customers/trusted-entitlements.cs
+++ b/code_blocks/👥 Customers/trusted-entitlements.cs
@@ -1,0 +1,5 @@
+Purchases.PurchasesConfiguration.Builder builder = Purchases.PurchasesConfiguration.Builder.Init(<public_api_key>);
+Purchases.PurchasesConfiguration purchasesConfiguration =
+    .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Informational)
+    .Build();
+purchases.Configure(purchasesConfiguration);

--- a/code_blocks/👥 Customers/trusted-entitlements.dart
+++ b/code_blocks/👥 Customers/trusted-entitlements.dart
@@ -1,0 +1,3 @@
+PurchasesConfiguration configuration = PurchasesConfiguration(<public_api_key>);
+configuration.entitlementVerificationMode = EntitlementVerificationMode.informational;
+await Purchases.configure(configuration);

--- a/code_blocks/👥 Customers/verification-result-capacitor.ts
+++ b/code_blocks/👥 Customers/verification-result-capacitor.ts
@@ -1,0 +1,21 @@
+const customerInfo = await Purchases.getCustomerInfo().customerInfo;
+switch (customerInfo.entitlements.verification) {
+    // No verification was done.
+    //
+    // This can happen for multiple reasons:
+    //  1. Verification is not enabled in Configuration
+    //  2. Verification can't be performed prior to Android 4.4
+    case VERIFICATION_RESULT.NOT_REQUESTED:
+
+    // Entitlements were verified with our server.
+    case VERIFICATION_RESULT.VERIFIED:
+
+    // Entitlements were verified on device.
+    case VERIFICATION_RESULT.VERIFIED_ON_DEVICE:
+        // Grant access
+        break;
+
+    case VERIFICATION_RESULT.FAILED:
+        // Failed verification
+        break;
+}

--- a/code_blocks/👥 Customers/verification-result-rn.ts
+++ b/code_blocks/👥 Customers/verification-result-rn.ts
@@ -1,0 +1,21 @@
+const customerInfo = await Purchases.getCustomerInfo();
+switch (customerInfo.entitlements.verification) {
+    // No verification was done.
+    //
+    // This can happen for multiple reasons:
+    //  1. Verification is not enabled in Configuration
+    //  2. Verification can't be performed prior to Android 4.4
+    case VERIFICATION_RESULT.NOT_REQUESTED:
+
+    // Entitlements were verified with our server.
+    case VERIFICATION_RESULT.VERIFIED:
+
+    // Entitlements were verified on device.
+    case VERIFICATION_RESULT.VERIFIED_ON_DEVICE:
+        // Grant access
+        break;
+
+    case VERIFICATION_RESULT.FAILED:
+        // Failed verification
+        break;
+}

--- a/code_blocks/👥 Customers/verification-result.cs
+++ b/code_blocks/👥 Customers/verification-result.cs
@@ -1,0 +1,24 @@
+purchases.GetCustomerInfo((info, error) =>
+{
+    switch (info.Entitlements.Verification) {
+        // No verification was done.
+        //
+        // This can happen for multiple reasons:
+        //  1. Verification is not enabled in Configuration
+        //  2. Verification can't be performed prior to Android 4.4
+        case Purchases.VerificationResult.NotRequested:
+
+        // Entitlements were verified with our server.
+        case Purchases.VerificationResult.Verified:
+
+        // Entitlements were verified on device.
+        case Purchases.VerificationResult.VerifiedOnDevice:
+            // Grant access
+            break;
+
+        // Entitlement verification failed, possibly due to a MiTM attack.
+        case Purchases.VerificationResult.Failed:
+            // Verification failed
+            break;
+    }
+});

--- a/code_blocks/👥 Customers/verification-result.dart
+++ b/code_blocks/👥 Customers/verification-result.dart
@@ -1,0 +1,22 @@
+final customerInfo = await Purchases.getCustomerInfo();
+switch (customerInfo.entitlements.verification) {
+  // No verification was done.
+  //
+  // This can happen for multiple reasons:
+  //  1. Verification is not enabled in Configuration
+  //  2. Verification can't be performed prior to Android 4.4
+  case VerificationResult.notRequested:
+
+  // Entitlements were verified with our server.
+  case VerificationResult.verified:
+
+  // Entitlements were verified on device.
+  case VerificationResult.verifiedOnDevice:
+    // Grant access
+    break;
+
+  // Entitlement verification failed, possibly due to a MiTM attack.
+  case VerificationResult.failed:
+    // Failed verification
+    break;
+}

--- a/docs_source/👥 Customers/trusted-entitlements.md
+++ b/docs_source/👥 Customers/trusted-entitlements.md
@@ -133,4 +133,3 @@ In this way, apps using the old version of the SDK would continue to work, but t
 
 - Android 4.4+
 - iOS 13.x+
-- _Coming soon to our other SDKs_

--- a/docs_source/👥 Customers/trusted-entitlements.md
+++ b/docs_source/👥 Customers/trusted-entitlements.md
@@ -43,6 +43,26 @@ SDKs can be configured in one of 3 `EntitlementVerificationMode`'s:
     "language": "kotlin",
     "name": "",
     "file": "code_blocks/👥 Customers/trusted-entitlements.kt"
+  },
+  {
+    "language": "dart",
+    "name": "Flutter",
+    "file": "code_blocks/👥 Customers/trusted-entitlements.dart"
+  },
+  {
+    "language": "typescript",
+    "name": "React native",
+    "file": "code_blocks/👥 Customers/trusted-entitlements-rn.ts"
+  },
+  {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/👥 Customers/trusted-entitlements-capacitor.ts"
+  },
+  {
+    "language": "csharp",
+    "name": "Unity",
+    "file": "code_blocks/👥 Customers/trusted-entitlements.cs"
   }
 ]
 [/block]
@@ -67,6 +87,26 @@ When configuring the SDK with `EntitlementVerificationMode.informational`, `Enti
     "language": "kotlin",
     "name": "",
     "file": "code_blocks/👥 Customers/verification-result.kt"
+  },
+  {
+    "language": "dart",
+    "name": "Flutter",
+    "file": "code_blocks/👥 Customers/verification-result.dart"
+  },
+  {
+    "language": "typescript",
+    "name": "React native",
+    "file": "code_blocks/👥 Customers/verification-result-rn.ts"
+  },
+  {
+    "language": "typescript",
+    "name": "Capacitor",
+    "file": "code_blocks/👥 Customers/verification-result-capacitor.ts"
+  },
+  {
+    "language": "csharp",
+    "name": "Unity",
+    "file": "code_blocks/👥 Customers/verification-result.cs"
   }
 ]
 [/block]


### PR DESCRIPTION
## Motivation / Description
This adds code samples on how to use trusted entitlements in the hybrids, which had support added in the latest version of the hybrid SDKs:
https://www.revenuecat.com/docs/trusted-entitlements
