### PR TITLE
Add Danger and check for modifications of rendered_docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,13 @@ jobs:
 workflows:
   version: 2
 
+  danger:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - revenuecat/danger
+
   open-syncing-pr:
     jobs:
       - open-syncing-pr:

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,5 @@
+has_rendered_docs_changes = !git.modified_files.grep(/rendered_docs/).empty?
+
+if has_rendered_docs_changes && github.pr_author != "RCGitBot"
+    fail "Don't modify files in the rendered_docs folder"
+end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,5 @@
 has_rendered_docs_changes = !git.modified_files.grep(/rendered_docs/).empty?
 
 if has_rendered_docs_changes && github.pr_author != "RCGitBot"
-    fail "Don't modify files in the rendered_docs folder"
+    fail "Don't modify files in the rendered_docs folder. Changes should me made inside the docs_source folder"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem 'danger'
 gem "fastlane"
 
 gem "rspec", "~> 3.12"


### PR DESCRIPTION
Adds Danger and a check for modifications on files inside the `rendered_docs` folder. This is how an error looks like:

<img width="523" alt="Screenshot 2023-11-24 at 17 49 29" src="https://github.com/RevenueCat/revenuecat-docs/assets/664544/0b76cf08-042c-4bf5-b240-d852039dba61">
