### PR TITLE
Fix android debug view dependency name

### DIFF
--- a/code_blocks/🧰 Test - Launch/debugging_13.groovy
+++ b/code_blocks/🧰 Test - Launch/debugging_13.groovy
@@ -1,2 +1,2 @@
-debugImplementation "com.revenuecat.purchase:purchases-debugview:6.9.2"
-releaseImplementation "com.revenuecat.purchase:purchases-debugview-noop:6.9.2"
+debugImplementation "com.revenuecat.purchases:purchases-debug-view:6.9.2"
+releaseImplementation "com.revenuecat.purchases:purchases-debug-view-noop:6.9.2"


### PR DESCRIPTION
## Motivation / Description
We changed the debug view package name in maven before releasing but we didn't update the docs. This updates the docs to use the correct dependency. As reported in https://community.revenuecat.com/sdks-51/wrong-dependency-in-the-doc-for-debug-ui-on-android-3703

