### PR TITLE
Update singular.md to reflect the Singular integration

### DIFF
--- a/docs_source/Integrations & Events/attribution/singular.md
+++ b/docs_source/Integrations & Events/attribution/singular.md
@@ -105,7 +105,7 @@ You can test the Singular integration end-to-end before going live. It's recomme
 
 ## Add a sandbox SDK key in the RevenueCat dashboard
 
-Before you test the integration, make sure you have a Singular SDK key set in the "Sandbox API key" field in RevenueCat. This is required if you want the integration to trigger for sandbox purchases.
+Before you test the integration, make sure you have a Singular SDK key set in the "SDK key (sandbox)" field in RevenueCat. This is required if you want the integration to trigger for sandbox purchases.
 
 ## Make a sandbox purchase with a new user
 


### PR DESCRIPTION
## Motivation / Description
Singular has requested that we use the phrase SDK key, instead of API key. We have had to update this in a variety of places and I was just updating a phrase which referred to the old phrase that we used in the frontend of the integration in RevenueCat

## Changes introduced
fixed the phrase ""Sandbox API key" field" to ""SDK key (sandbox) field"

## Linear ticket (if any)

## Additional comments
