### PR TITLE
Make in app purchases key mandatory

### DIFF
--- a/docs_source/Getting Started/getting-started.md
+++ b/docs_source/Getting Started/getting-started.md
@@ -64,7 +64,7 @@ From **Project Settings > Apps** in the left menu of the project dashboard, sele
 }
 [/block]
 
-The field **App name** is required to add your app to RevenueCat. To make test and production purchases, the **Bundle ID** (iOS) / **Package Name** (Android) as well as the **Shared Secret** (iOS) / **Service Credentials** (Android) **must be configured**.
+The field **App name** is required to add your app to RevenueCat. To make test and production purchases, the **Bundle ID** (iOS) / **Package Name** (Android) as well as the **Shared Secret** and **In-App Purchase Key**(iOS) / **Service Credentials** (Android) **must be configured**.
 
 > 📘 
 > 
@@ -104,7 +104,7 @@ The rest of the configuration fields can be added later.
 
 ## ▶️ Service Credentials
 
-Service credentials need to be set up for RevenueCat to communicate with the app stores on your behalf. See our guides [App Store Connect Shared Secret](doc:itunesconnect-app-specific-shared-secret), [Play Service Credentials](doc:creating-play-service-credentials), and [Amazon Appstore Shared Secret](doc:amazon-appstore) for more information. 
+Service credentials need to be set up for RevenueCat to communicate with the app stores on your behalf. See our guides [App Store Connect Shared Secret](doc:itunesconnect-app-specific-shared-secret), [App Store In-App Purchase Key](doc:in-app-purchase-key-configuration), [Play Service Credentials](doc:creating-play-service-credentials), and [Amazon Appstore Shared Secret](doc:amazon-appstore) for more information. 
 
 Note that Play service credentials can take up to 36 hours to propagate throughout Google's servers.
 

--- a/docs_source/Getting Started/getting-started.md
+++ b/docs_source/Getting Started/getting-started.md
@@ -64,7 +64,7 @@ From **Project Settings > Apps** in the left menu of the project dashboard, sele
 }
 [/block]
 
-The field **App name** is required to add your app to RevenueCat. To make test and production purchases, the **Bundle ID** (iOS) / **Package Name** (Android) as well as the **Shared Secret** and **In-App Purchase Key**(iOS) / **Service Credentials** (Android) **must be configured**.
+The field **App name** is required to add your app to RevenueCat. For iOS apps **In-App Purchase Key**(iOS) is also required. To make test and production purchases, the **Bundle ID** (iOS) / **Package Name** (Android) as well as the **Shared Secret**(iOS) / **Service Credentials** (Android) **must be configured**.
 
 > 📘 
 > 
@@ -72,13 +72,14 @@ The field **App name** is required to add your app to RevenueCat. To make test a
 
 The rest of the configuration fields can be added later. 
 
+
 [block:image]
 {
   "images": [
     {
       "image": [
-        "https://files.readme.io/6b4ca31-Screen_Shot_2022-11-16_at_3.35.46_PM.png",
-        "Screen Shot 2022-11-16 at 3.35.46 PM.png",
+        "https://github.com/RevenueCat/revenuecat-docs/assets/5860245/7ddfb6e9-d730-4440-baba-d94bef820288",
+        "iOS App Creation Form.png",
         1682
       ],
       "align": "center",

--- a/docs_source/Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
+++ b/docs_source/Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
@@ -33,7 +33,8 @@ In the RevenueCat dashboard, select your iOS app from the **Apps** tab in your p
 
 Within your app settings, under the tab **In-app purchase key configuration**, you'll see an area to upload your In-App Purchase Key .p8 file that you downloaded from App Store Connect.
 
-![](https://files.readme.io/29734b9-app.revenuecat.com_projects_85ff18c7_apps_appefe5647c50_2.png)
+
+![](https://github.com/RevenueCat/revenuecat-docs/assets/5860245/ae091b84-891d-4132-842c-3d35d9c66d4a)
 
 
 
@@ -50,8 +51,7 @@ Copy the Issuer ID, which is now shown at the top of the page, and paste into th
 ![](https://files.readme.io/ab962c9-Screenshot_at_Feb_01_12-02-57.png "Screenshot at Feb 01 12-02-57.png")
 
 
-
-![](https://files.readme.io/6b5df1b-issuer_id.png "issuer_id.png")
+![](https://github.com/RevenueCat/revenuecat-docs/assets/5860245/fdd4e307-8eaa-4bfe-a3e4-56f590106991)
 
 
 

--- a/docs_source/Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
+++ b/docs_source/Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
@@ -5,7 +5,7 @@ excerpt: Guide on how to set up iOS in-app purchase keys.
 hidden: false
 parentDoc: 649983b4c31b2e000a3c1859
 ---
-For RevenueCat to securely validate purchases through Apple Store Kit 2, authenticate and validate [Subscription Offers](https://docs.revenuecat.com/docs/ios-subscription-offers) request with Apple and enable [customer lookup](https://docs.revenuecat.com/docs/customer-lists#find-an-individual-customer) via Order ID for iOS apps you need to upload an in-app purchase key, Key ID and Issuer ID. Find instructions on how to do it below. 
+For RevenueCat to securely validate purchases through Apple Store Kit 2, authenticate and validate [Subscription Offers](https://docs.revenuecat.com/docs/ios-subscription-offers) request with Apple and enable [customer lookup](https://docs.revenuecat.com/docs/customer-lists#find-an-individual-customer) via Order ID for iOS apps, you need to upload an in-app purchase key, and you'll also need to provide an Issuer ID.
 
 ## 1. Generating an In-App Purchase Key
 

--- a/docs_source/Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
+++ b/docs_source/Service Credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.md
@@ -5,7 +5,7 @@ excerpt: Guide on how to set up iOS in-app purchase keys.
 hidden: false
 parentDoc: 649983b4c31b2e000a3c1859
 ---
-For RevenueCat to securely authenticate and validate a [Subscription Offer](https://docs.revenuecat.com/docs/ios-subscription-offers) request with Apple, you'll need to upload an in-app purchase key. In order to enable [customer lookup](https://docs.revenuecat.com/docs/customer-lists#find-an-individual-customer) via Order ID for iOS apps, you'll also need to provide an Issuer ID.
+For RevenueCat to securely validate purchases through Apple Store Kit 2, authenticate and validate [Subscription Offers](https://docs.revenuecat.com/docs/ios-subscription-offers) request with Apple and enable [customer lookup](https://docs.revenuecat.com/docs/customer-lists#find-an-individual-customer) via Order ID for iOS apps you need to upload an in-app purchase key, Key ID and Issuer ID. Find instructions on how to do it below. 
 
 ## 1. Generating an In-App Purchase Key
 


### PR DESCRIPTION
## Motivation / Description

We made In App Purchase keys mandatory to speed up adoption of SK2. Reflecting this in the docs

## Linear ticket (if any)
https://linear.app/revenuecat/issue/CAT-1272/[frontent]-mark-in-app-purchases-key-as-mandatory
