### PR TITLE
`Paywalls`: improve docs for presenting manually

### DIFF
--- a/code_blocks/🛠 Tools/paywalls/paywalls_3.swift
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_3.swift
@@ -11,6 +11,12 @@ struct App: View {
         ContentView()
             .sheet(isPresented: self.$displayPaywall) {
                 PaywallView(displayCloseButton: true)
+                    .onPurchaseCompleted { _ in
+                        // When presenting paywalls manually, it's also 
+                        // your responsponsibility to dismiss it when desired,
+                        // like when a purchase is completed.
+                        self.displayPaywall = nil
+                    }
             }
     }
 }

--- a/code_blocks/🛠 Tools/paywalls/paywalls_4.swift
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_4.swift
@@ -18,7 +18,10 @@ extension ViewController: PaywallViewControllerDelegate {
 
     func paywallViewController(_ controller: PaywallViewController,
                                didFinishPurchasingWith customerInfo: CustomerInfo) {
-
+        // When presenting paywalls manually, it's also
+        // your responsponsibility to dismiss it when desired,
+        // like when a purchase is completed.
+        [controller dismissViewControllerAnimated: true completion:nil];
     }
 
 }


### PR DESCRIPTION
We needed to show how to manually dismiss paywalls when presenting manually.

See https://github.com/RevenueCat/purchases-ios/issues/3516
