### PR TITLE
Fix RN deprecated purchaseProduct

### DIFF
--- a/code_blocks/🚀 Getting Started/making-purchases_6.js
+++ b/code_blocks/🚀 Getting Started/making-purchases_6.js
@@ -11,9 +11,9 @@ try {
 }
 
 // -----
-// If you are NOT using Offerings/Packages:
-await Purchases.purchaseProduct("product_id");
-
-// Or, optionally provide the product type as the third parameter. Defaults to PURCHASE_TYPE.SUBS
-// The `null` second parameter is the `upgradeInfo` object discussed here: https://www.revenuecat.com/docs/managing-subscriptions#google-play
-await Purchases.purchaseProduct("product_id", null, Purchases.PURCHASE_TYPE.INAPP);
+// If you are NOT using Offerings/Packages, first fetch the store products
+const products: PurchasesStoreProduct[] = await Purchases.getProducts(
+    ["product_id"],
+    PURCHASE_TYPE.INAPP
+);
+await Purchases.purchaseStoreProduct(products[0]);

--- a/code_blocks/🚀 Getting Started/making-purchases_6.js
+++ b/code_blocks/🚀 Getting Started/making-purchases_6.js
@@ -1,7 +1,7 @@
 // Using Offerings/Packages
 try {
   const {customerInfo, productIdentifier} = await Purchases.purchasePackage(package);
-  if (typeof customerInfo.entitlements.active.my_entitlement_identifier !== "undefined") {
+  if (typeof purchaseResult.customerInfo.entitlements.active['my_entitlement_identifier'] !== "undefined") {
     // Unlock that great "pro" content
   }
 } catch (e) {
@@ -10,10 +10,15 @@ try {
   }
 }
 
-// -----
-// If you are NOT using Offerings/Packages, first fetch the store products
-const products: PurchasesStoreProduct[] = await Purchases.getProducts(
-    ["product_id"],
-    PURCHASE_TYPE.INAPP
-);
-await Purchases.purchaseStoreProduct(products[0]);
+// Note: if you are not using offerings/packages to purchase In-app products, you can use purchaseStoreProduct and getProducts
+
+try {
+  const {customerInfo, productIdentifier} = await Purchases.purchaseStoreProduct(productToBuy);
+  if (typeof purchaseResult.customerInfo.entitlements.active['my_entitlement_identifier'] !== "undefined") {
+    // Unlock that great "pro" content
+  }
+} catch (e) {
+  if (!e.userCancelled) {
+    showError(e);
+  }
+}


### PR DESCRIPTION
As mentioned in https://github.com/RevenueCat/react-native-purchases/issues/809, the `purchaseProduct` code in the react native snippet is deprecated