### PR TITLE
Update google-play-offers.md

### DIFF
--- a/docs_source/Subscription Guidance/subscription-offers/google-play-offers.md
+++ b/docs_source/Subscription Guidance/subscription-offers/google-play-offers.md
@@ -4,6 +4,12 @@ slug: google-play-offers
 excerpt: Setting up your offers in Google Play Console
 hidden: false
 ---
+> 🚧 Google Promo Codes will be treated as regular purchases
+>
+> Due to limitations in Google's Play Billing Library 5, we are currently unable to detect when promo codes are redeemed to purchase a subscription.
+>
+> All purchases will be reflected in RevenueCat at full-price.
+
 [block:callout]
 {
   "type": "success",


### PR DESCRIPTION
## Motivation / Description
We can't detect Google promo codes until they update their Subscriptions API.

## Changes introduced
Added a callout to our Google Promo Codes docs warning users of this.

## Linear ticket (if any)

## Additional comments
