### PR TITLE
update AppEvents to use singleton

### DIFF
--- a/code_blocks/🔌 Integrations & Events/attribution/facebook-ads_1.swift
+++ b/code_blocks/🔌 Integrations & Events/attribution/facebook-ads_1.swift
@@ -8,7 +8,7 @@ Purchases.configure(withAPIKey: "public_sdk_key")
 Purchases.shared.attribution.collectDeviceIdentifiers()
 
 // REQUIRED: Set the Facebook anonymous Id
-Purchases.shared.attribution.setFBAnonymousID(FBSDKCoreKit.AppEvents.anonymousID)
+Purchases.shared.attribution.setFBAnonymousID(FBSDKCoreKit.AppEvents.shared.anonymousID)
 
 // Optionally set additional user data
 Purchases.shared.attribution.setEmail("test@example.com")


### PR DESCRIPTION
## Motivation / Description

A developer wrote in saying they were getting this error: `Instance member 'anonymousID' cannot be used on type 'AppEvents'; did you mean to use a value of this type instead?`

Looks like Facebook updated their SDK to use a singleton instead.

Evidence:

1. https://stackoverflow.com/questions/71723809/instance-member-logevent-cannot-be-used-on-type-appevents-did-you-mean-to-u
2. https://github.com/facebook/facebook-ios-sdk/blob/main/CHANGELOG.md#:~:text=Removed%20deprecated%20AppEvents.anonymousID%20(use%20AppEvents.shared.anonymousID%20instead)

## Changes introduced

Find `FBSDKCoreKit.AppEvents.anonymousID`

Replace `FBSDKCoreKit.AppEvents.shared.anonymousID`

## Linear ticket (if any)

none

## Additional comments

none