### PR TITLE
Indicate React Naitve footer is only supported in Portrait

### DIFF
--- a/docs_source/Tools/paywalls.md
+++ b/docs_source/Tools/paywalls.md
@@ -102,6 +102,11 @@ implementation 'com.revenuecat.purchases:purchases-ui:7.1.0'
 }
 ```
 
+> ❗️
+> 
+> `PaywallFooterContainerView` only works correctly when phone is in portrait mode.
+> Landscape mode support for `PaywallFooterContainerView` is coming soon.
+
 ## Flutter Installation
 
 - Add `purchases-ui-flutter` in your `pubspec.yaml`:


### PR DESCRIPTION
![image](https://github.com/RevenueCat/revenuecat-docs/assets/664544/a3adf502-4c10-430a-9f8b-b3bcf293a5ce)

We realised the footer doesn't work properly in landscape mode in React Native