### PR TITLE
Adding preview descritpion to paywall docs

### DIFF
--- a/docs_source/Tools/paywalls/creating-paywalls.md
+++ b/docs_source/Tools/paywalls/creating-paywalls.md
@@ -88,9 +88,10 @@ We support the following variables:
 | sub_offer_price           | The localized price of the introductory offer of a given package                                        | $4.99                |
 | sub_offer_price_2         | The localized price of the second introductory offer of a given package (Google Play only)              | $4.99                |
 
-> 📘 
-> 
-> Click the **Show preview values** checkbox to see your Paywall with example preview values instead of the raw variables.
+## Previewing Paywalls
+Click the **Show preview values** checkbox to see your Paywall with example preview values instead of the raw variables.
+
+The paywall preview is generated using our example data. Please note that you may observe placeholder values from the example values in the table above, such as product names or prices in the preview of your newly created paywall. To obtain a more accurate preview, we recommend running your application on your physical device or in the simulator, as this will present details more closely aligned with your actual product information.
 
 ## Intro offer eligibility
 


### PR DESCRIPTION
I have been getting a lot of tickets about the paywall preview being not accurate so I feel we need to make it more clear that we are using example data in the preview.