### PR TITLE
Added close button callout for android

### DIFF
--- a/docs_source/Tools/paywalls/displaying-paywalls.md
+++ b/docs_source/Tools/paywalls/displaying-paywalls.md
@@ -39,7 +39,7 @@ RevenueCat Paywalls will, by default, show paywalls fullscreen and there are mul
 ]
 [/block]
 
-## Close Button
+## iOS Close Button
 
 Paywalls displayed with `presentPaywallIfNeeded` will have a close button on the presented sheet.
 However, a `PaywallView` will not have a close button by default. This gives you full control on how to to navigate to and from your `PaywallView`. You can push it onto an existing navigation stack or show it in a sheet with a custom dismiss button using SwiftUI toolbar.
@@ -136,6 +136,13 @@ RevenueCat Paywalls will, by default, show paywalls fullscreen and there are mul
   }
 ]
 [/block]
+
+## Android Close Button
+
+Paywalls displayed with `Paywall` will have a close button on the presented sheet.
+However, a `PaywallDialog` will not have a close button by default. This gives you full control over how to navigate to and from your `PaywallDialog`. You can push this to the existing navigation stack or display it in a sheet with a custom dismiss button using Android's navigation components and fragments.
+
+If desired, you can pass `shoulDisplayDismissButton: true` when creating `PaywallView` to display a close button automatically.
 
 ## How to display a footer Paywall on your custom paywall
 


### PR DESCRIPTION
We have a section in the iOS section on how to add a close button but we didn't have anything for Android. I went ahead and added this section for Android.

## Motivation / Description
Ticket here: https://revenuecat.zendesk.com/agent/tickets/35793
Slack: https://revenuecat.slack.com/archives/C057L62KGJY/p1705691874521419

## Changes introduced
Added section for Android close button