### PR TITLE
Attempt to make CANCELLATION event description clearer

### DIFF
--- a/docs_source/Integrations & Events/webhooks/event-types-and-fields.md
+++ b/docs_source/Integrations & Events/webhooks/event-types-and-fields.md
@@ -40,7 +40,7 @@ RevenueCat sends webhooks in response to events that occur in your app. Here the
     "2-5": "✅",
     "2-6": "❌",
     "3-0": "`CANCELLATION`",
-    "3-1": "A subscription or non-renewing purchase has been cancelled or refunded. Note that in the event of refunds, a subscription's auto-renewal setting may still be active. See [cancellation reasons](https://www.revenuecat.com/docs/event-types-and-fields#cancellation-and-expiration-reasons) for more details. This event won't be sent if there's refund corresponding to a subscription period that is not the latest one.",
+    "3-1": "A subscription or non-renewing purchase has been cancelled or refunded. Note that in the event of refunds, a subscription's auto-renewal setting may still be active. See [cancellation reasons](https://www.revenuecat.com/docs/event-types-and-fields#cancellation-and-expiration-reasons) for more details. Note that, for the case of subscription refunds, this event is only fired if the latest subscription period of a subscription is refunded, refunds for earlier subscription periods do not trigger this event.",
     "3-2": "✅",
     "3-3": "✅",
     "3-4": "✅",

--- a/docs_source/Integrations & Events/webhooks/event-types-and-fields.md
+++ b/docs_source/Integrations & Events/webhooks/event-types-and-fields.md
@@ -40,7 +40,7 @@ RevenueCat sends webhooks in response to events that occur in your app. Here the
     "2-5": "✅",
     "2-6": "❌",
     "3-0": "`CANCELLATION`",
-    "3-1": "A subscription or non-renewing purchase has been cancelled or refunded. Note that in the event of refunds, a subscription's auto-renewal setting may still be active. See [cancellation reasons](https://www.revenuecat.com/docs/event-types-and-fields#cancellation-and-expiration-reasons) for more details.",
+    "3-1": "A subscription or non-renewing purchase has been cancelled or refunded. Note that in the event of refunds, a subscription's auto-renewal setting may still be active. See [cancellation reasons](https://www.revenuecat.com/docs/event-types-and-fields#cancellation-and-expiration-reasons) for more details. This event won't be sent if there's refund corresponding to a subscription period that is not the latest one.",
     "3-2": "✅",
     "3-3": "✅",
     "3-4": "✅",


### PR DESCRIPTION
## Motivation / Description
In the docs, we say that we send a `CANCELLATION` event can be sent for refunds. However, for subscriptions, this is only true if the refund is for the latest period. If an older transaction (subscription period) is refunded, we won't generate this event.


## Changes introduced

## Linear ticket (if any)
https://linear.app/revenuecat/issue/ECO-450/room-planner-not-all-refunds-fired

## Additional comments
