### PR TITLE
Instructions for subscription offers testing

### DIFF
--- a/docs_source/Test - Launch/sandbox/apple-app-store.md
+++ b/docs_source/Test - Launch/sandbox/apple-app-store.md
@@ -205,6 +205,38 @@ Go to your app's configuration page in your RevenueCat project settings (**Proje
 > 
 > You're ready to make purchases locally in the simulator!
 
+# Testing Subscription Offers on the Simulator 
+For sandbox and production [subscription offers](doc:ios-subscription-offers), they are signed using the [In-App Key](doc:in-app-purchase-key-configuration). However, when using a StoreKit Configuration file, the key used to sign offers must be exported from Xcode directly.
+
+## Step 1: Finding your Subscription Offers Key
+Open the  `.storekit` file where the promotional offers are configured, and go to Editor → Subscription Offers Key.
+<img width="505" alt="Find Subscription Offers Key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/25ec7b3e-312d-46e1-afb4-549714da9487">
+
+After selecting 'Subscription Offers Key', you will see your key ID and private key. 
+<img width="575" alt="Key ID and private key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/e83f6f2e-e4dc-4354-874f-27281f7e1acf">
+
+Note that the private key stored in the “.storekit” file is unique per file and Xcode allows you to re-generate the key for a given file. If you re-generate your key, be sure to follow these steps again to upload your new key to RevenueCat.
+
+## Step 2: Save your private key as a .p8 file
+You will notice that there is no option to download the key. Manually save the text of the key in a file called `SubscriptionKey_XXXXXX.p8` where `XXXXXX` is the key ID. Following this example, the file would be named `SubscriptionKey_BD3A7A04.p8`.
+
+We only accept files smaller than 512B. We recommend utilizing an editor such as Visual Studio Code when creating your .p8 file. 
+
+## Step 3: Upload your file to RevenueCat
+This file can now be uploaded to the RevenueCat dashboard under your iOS app settings page → Storekit Subscription Offer Key.
+
+<img width="904" alt="Upload Storekit Subscription Offer Key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/e91c1d44-9036-446b-86c5-62f707b9e208">
+
+Be sure to copy and paste over your key ID from Xcode to the `Key ID` box.
+
+<img width="898" alt="Add key ID" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/44dfcdcb-ccc0-46a3-80e6-68b887f68f38">
+
+Don't forget to click 'Save Changes' in the upper right after you added your key ID.
+
+> 👍 You did it!
+> 
+> You're ready to make Subscription Offer purchases locally in the simulator!
+
 # Make a Purchase
 
 Build and run your app on your device. When you attempt to make a purchase, you may be still be prompted to sign in with the sandbox account you just created. 

--- a/docs_source/Test - Launch/sandbox/apple-app-store.md
+++ b/docs_source/Test - Launch/sandbox/apple-app-store.md
@@ -210,7 +210,7 @@ For sandbox and production [subscription offers](doc:ios-subscription-offers), t
 
 ## Step 1: Finding your Subscription Offers Key
 Open the  `.storekit` file where the subscriptions offers are configured, and go to Editor → Subscription Offers Key.
-<img width="505" alt="Find Subscription Offers Key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/25ec7b3e-312d-46e1-afb4-549714da9487">
+<img width="517" alt="Find Subscription Offers Key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/57cf8008-7c6e-4103-b8ad-6e4e2b9bb0a0">
 
 After selecting 'Subscription Offers Key', you will see your key ID and private key. 
 <img width="575" alt="Key ID and private key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/e83f6f2e-e4dc-4354-874f-27281f7e1acf">

--- a/docs_source/Test - Launch/sandbox/apple-app-store.md
+++ b/docs_source/Test - Launch/sandbox/apple-app-store.md
@@ -209,7 +209,7 @@ Go to your app's configuration page in your RevenueCat project settings (**Proje
 For sandbox and production [subscription offers](doc:ios-subscription-offers), they are signed using the [In-App Key](doc:in-app-purchase-key-configuration). However, when using a StoreKit Configuration file, the key used to sign offers must be exported from Xcode directly.
 
 ## Step 1: Finding your Subscription Offers Key
-Open the  `.storekit` file where the promotional offers are configured, and go to Editor → Subscription Offers Key.
+Open the  `.storekit` file where the subscriptions offers are configured, and go to Editor → Subscription Offers Key.
 <img width="505" alt="Find Subscription Offers Key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/25ec7b3e-312d-46e1-afb4-549714da9487">
 
 After selecting 'Subscription Offers Key', you will see your key ID and private key. 
@@ -218,7 +218,7 @@ After selecting 'Subscription Offers Key', you will see your key ID and private 
 Note that the private key stored in the “.storekit” file is unique per file and Xcode allows you to re-generate the key for a given file. If you re-generate your key, be sure to follow these steps again to upload your new key to RevenueCat.
 
 ## Step 2: Save your private key as a .p8 file
-You will notice that there is no option to download the key. Manually save the text of the key in a file called `SubscriptionKey_XXXXXX.p8` where `XXXXXX` is the key ID. Following this example, the file would be named `SubscriptionKey_BD3A7A04.p8`.
+Manually save the text of the private key in a file called `SubscriptionKey_XXXXXX.p8` where `XXXXXX` is the key ID. Following this example, the file would be named `SubscriptionKey_BD3A7A04.p8`.
 
 We only accept files smaller than 512B. We recommend utilizing an editor such as Visual Studio Code when creating your .p8 file. 
 

--- a/docs_source/Test - Launch/sandbox/apple-app-store.md
+++ b/docs_source/Test - Launch/sandbox/apple-app-store.md
@@ -223,15 +223,11 @@ Manually save the text of the private key in a file called `SubscriptionKey_XXXX
 We only accept files smaller than 512B. We recommend utilizing an editor such as Visual Studio Code when creating your .p8 file. 
 
 ## Step 3: Upload your file to RevenueCat
-This file can now be uploaded to the RevenueCat dashboard under your iOS app settings page → Storekit Subscription Offer Key.
-
-<img width="904" alt="Upload Storekit Subscription Offer Key" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/e91c1d44-9036-446b-86c5-62f707b9e208">
-
-Be sure to copy and paste over your key ID from Xcode to the `Key ID` box.
+This file can now be uploaded to the RevenueCat dashboard under your iOS app settings page → Storekit Subscription Offer Key. Be sure to copy and paste over your key ID from Xcode to the `Key ID` box.
 
 <img width="898" alt="Add key ID" src="https://github.com/RevenueCat/revenuecat-docs/assets/36222014/44dfcdcb-ccc0-46a3-80e6-68b887f68f38">
 
-Don't forget to click 'Save Changes' in the upper right after you added your key ID.
+Don't forget to click 'Save Changes' in the upper right.
 
 > 👍 You did it!
 > 


### PR DESCRIPTION
## Motivation / Description
When using a StoreKit Configuration file, the key used to sign offers must be exported from Xcode. This documentation outlines to developers where to find this key and upload to RevenueCat.

## Changes introduced

## Linear ticket (if any)
https://linear.app/revenuecat/issue/CAT-1331/[documentation]-storekit-subscriptions-offer-key-explainer

## Additional comments
