### PR TITLE
`React Native Paywalls`: added offering parameter to `presentPaywall` calls

### DIFF
--- a/code_blocks/🛠 Tools/paywalls/paywalls_rn_1.ts
+++ b/code_blocks/🛠 Tools/paywalls/paywalls_rn_1.ts
@@ -1,7 +1,9 @@
 import RevenueCatUI, { PAYWALL_RESULT } from "react-native-purchases-ui";
 
 async function presentPaywall(): Promise<boolean> {
-    const paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywall();
+    const paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywall({
+        offering: offering // Optional offering parameter
+    });
 
     switch (paywallResult) {
         case PAYWALL_RESULT.NOT_PRESENTED:
@@ -18,6 +20,7 @@ async function presentPaywall(): Promise<boolean> {
 
 async function presentPaywallIfNeeded() {
     const paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywallIfNeeded({
+        offering: offering, // Optional offering parameter
         requiredEntitlementIdentifier: "pro"
     });
 }


### PR DESCRIPTION
Follow up to #671.
