### PR TITLE
Add quickstart link to SDK reference

### DIFF
--- a/docs_source/Platform Resources/implementation-responsibilities.md
+++ b/docs_source/Platform Resources/implementation-responsibilities.md
@@ -55,7 +55,7 @@ For more information about the Dashboard and Charts, check out our docs [here](h
     "6-1": "✅",
     "7-0": "Syncing, parsing and verifying receipts",
     "7-2": "✅",
-    "8-0": "[Tracking entitlement status](https://docs.revenuecat.com/docs/purchaserinfo)",
+    "8-0": "[Tracking entitlement status](doc:purchaserinfo)",
     "8-2": "✅",
     "9-0": "[Tracking purchase history](https://docs.revenuecat.com/docs/customer-history)",
     "9-2": "✅",

--- a/docs_source/SDK Guides/reference.md
+++ b/docs_source/SDK Guides/reference.md
@@ -3,6 +3,10 @@ title: SDK Reference
 slug: reference
 hidden: true
 ---
+
+> 👍 Looking where to start?
+> If you are looking for a quick overlook and trying to get started, check the [SDK Quickstart](doc:getting-started) first.
+
 The API reference documentation provides detailed information for each of the classes and methods in the RevenueCat SDK. Choose your platform from the list below.
 
 

--- a/docs_source/Test - Launch/app-store-rejections.md
+++ b/docs_source/Test - Launch/app-store-rejections.md
@@ -93,7 +93,7 @@ There are momentary outages in sandbox from time-to-time, but occasionally outag
 
 Your app could also get rejected even if there are no issues during the purchase process, but the content does not get unlocked after purchasing. You should be able to reproduce this issue in a test environment.
 
-Double check that you're [checking the subscription status correctly](https://docs.revenuecat.com/docs/purchaserinfo) and all of the [products are added to Entitlements](https://docs.revenuecat.com/docs/entitlements) as needed.
+Double check that you're [checking the subscription status correctly](doc:purchaserinfo) and all of the [products are added to Entitlements](https://docs.revenuecat.com/docs/entitlements) as needed.
 
 # Other Tips
 


### PR DESCRIPTION
SDK reference might be visited by new developers and it can be a
a bit hard to digest.

This adds a note about the SDK Quickstart so new people find
where to start easily.
